### PR TITLE
enable shell server on all network interfaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,13 @@ run apt-get clean
 run sed -i "s|#node_auto_indexing|node_auto_indexing|g" /var/lib/neo4j/conf/neo4j.properties
 run sed -i "s|#node_keys_indexable|node_keys_indexable|g" /var/lib/neo4j/conf/neo4j.properties
 
+# enable shell server on all network interfaces
+run echo "remote_shell_host=0.0.0.0" >> /var/lib/neo4j/conf/neo4j.properties
+
+# expose REST and shell server ports
+expose 7474
+expose 1337
+
 workdir /
 
 ## entrypoint


### PR DESCRIPTION
this is needed for connecting with neo4j-shell running in a different container
