### PR TITLE
use `--cap-add` instead of `--privileged`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ With the Dockerfile on repository you've a docker neo4j community edition image 
 
 1. Execute this command:
 
-	`docker run -i -t -d --name neo4j --privileged -p 7474:7474 tpires/neo4j`
+	`docker run -i -t -d --name neo4j --cap-add=SYS_RESOURCE -p 7474:7474 tpires/neo4j`
 
 2. Access to http://localhost:7474 with your browser.

--- a/launch.sh
+++ b/launch.sh
@@ -3,5 +3,15 @@
 NEO4J_HOME=/var/lib/neo4j
 
 sed -i "s|#org.neo4j.server.webserver.address=0.0.0.0|org.neo4j.server.webserver.address=$HOSTNAME|g" $NEO4J_HOME/conf/neo4j-server.properties
-ulimit -n 65536 ; .$NEO4J_HOME/bin/neo4j console
+
+# doing this conditionally in case there is already a limit higher than what
+# we're setting here. neo4j recommends at least 40000.
+# 
+# (http://neo4j.com/docs/1.6.2/configuration-linux-notes.html#_setting_the_number_of_open_files)
+limit=`ulimit -n`
+if [ "$limit" -lt 65536 ]; then
+    ulimit -n 65536;
+fi
+    
+.$NEO4J_HOME/bin/neo4j console
 


### PR DESCRIPTION
ulimit only needs `CAP_SYS_RESOURCE`. `--privileged` is way overkill and shouldn't be used where avoidable.

Additionally, I noticed the default ulimit on my system was higher than what was being set in launch.sh, so I modified launch.sh to only set ulimit iff it is lower than what we want to set it to.